### PR TITLE
Update dockerfile to remove -e from echo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pear install mail_mime mail_mimedecode net_smtp net_idna2-beta auth_sasl net
 RUN rm -rf /var/www
 ADD . /var/www
 
-RUN echo -e '<?php\n$config = array();\n' > /var/www/config/config.inc.php
+RUN echo "<?php\n\$config = array();\n" > /var/www/config/config.inc.php
 RUN rm -rf /var/www/installer
 
 RUN . /etc/apache2/envvars && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/temp /var/www/logs


### PR DESCRIPTION
The -e option of echo does not exist in the sh of debian 8, so it writes a -e to config.inc.php. Using " instead of ' and escaping $ fixes this
